### PR TITLE
Use URL Encoded Form for OAuth2.0 token endpoint

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -195,6 +195,7 @@ const configureRequest = async (
       let requestCopy = cloneDeep(request);
       interpolateVars(requestCopy, envVars, collectionVariables, processEnvVars);
       const { data, url } = await resolveOAuth2AuthorizationCodecessToken(requestCopy);
+      request.headers['content-type'] = 'application/x-www-form-urlencoded';
       request.data = data;
       request.url = url;
     }


### PR DESCRIPTION
# Description
OAuth2.0 expects URL encoded form instead of JSON content
https://www.oauth.com/oauth2-servers/server-side-apps/example-flow/

Sample request body from official documentation

```
code=Yzk5ZDczMzRlNDEwY
&grant_type=code
&redirect_uri=https://example-app.com/cb
&client_id=mRkZGFjM
&client_secret=ZGVmMjMz
&code_verifier=Th7UHJdLswIYQxwSg29DbK1a_d9o41uNMTRmuH0PM8zyoMAQ
```

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
